### PR TITLE
Support the new Time API in Erlang 18.0

### DIFF
--- a/src/rabbit_clusterer_config.erl
+++ b/src/rabbit_clusterer_config.erl
@@ -140,9 +140,9 @@ create_node_id() ->
     %% started at this stage. We only need a fresh node_id when we're
     %% a virgin node. But we also want to ensure that when we are a
     %% virgin node our node id will be different from if we existed
-    %% previously, hence the use of now() which can go wrong if time
-    %% is set backwards, but we hope that won't happen.
-    erlang:md5(term_to_binary({node(), now()})).
+    %% previously, hence the use of erlang:system_time() which can go
+    %% wrong if time is set backwards, but we hope that won't happen.
+    erlang:md5(term_to_binary({node(), time_compat:erlang_system_time()})).
 
 %%----------------------------------------------------------------------------
 


### PR DESCRIPTION
It must be merged **after** rabbitmq/rabbitmq-server#254.

References rabbitmq/rabbitmq-server#233.
