### PR TITLE
Fix incorrect format string for preboot status

### DIFF
--- a/src/rabbit_clusterer.erl
+++ b/src/rabbit_clusterer.erl
@@ -46,7 +46,7 @@ status(Node) ->
     {Message, Config, List} =
         case rabbit_clusterer_coordinator:request_status(Node) of
             preboot ->
-                {"Clusterer is booting.~n", undefined, []};
+                {"Clusterer is pre-booting. ~p~n", undefined, []};
             {Config1, booting} ->
                 {"Clusterer is booting Rabbit into cluster configuration: "
                  "~n~s~n", Config1, []};


### PR DESCRIPTION
This is small fix that will report status instead of giving crash report. 
