### PR TITLE
Fix call to wait_for_replicated

### DIFF
--- a/src/rabbit_clusterer_utils.erl
+++ b/src/rabbit_clusterer_utils.erl
@@ -96,7 +96,7 @@ eliminate_mnesia_dependencies(NodesToDelete) ->
     %% tables actually exist.
     ok = rabbit_table:force_load(),
     case rabbit_table:is_present() of
-        true  -> ok = rabbit_table:wait_for_replicated();
+        true  -> ok = rabbit_table:wait_for_replicated(false);
         false -> ok
     end,
     %% del_table_copy has to be done after the force_load but is also


### PR DESCRIPTION
     - The signature of this function was changed in the latest version
     of rabbitmq-server
     (https://github.com/rabbitmq/rabbitmq-server/commit/a4f85212db5419559d5e35cf97ea0177b1576000#diff-0b6201ffba2cc08f6b43557bb4e1ab43)

Signed-off-by: Denise Yu <dyu@pivotal.io>